### PR TITLE
Update slugs

### DIFF
--- a/documentacion/como_empezar/README.md
+++ b/documentacion/como_empezar/README.md
@@ -106,12 +106,12 @@ como probar nuestros productos en este ambiente:
 
 - [Webpay Plus](webpay#webpay-plus)
 - [Webpay OneClick](webpay#webpay-oneclick)
-- [Onepay Checkout](onepay#integraci-n-checkout)
+- [Onepay Checkout](onepay#integracion-checkout)
 
 Después de haber realizado esas pruebas iniciales y antes del paso a producción
 tendrás que usar credenciales que identifiquen a tu comercio. De esa forma
 podrás realizar [la validación que te permitirá acceder a credenciales de
-producción](#el-proceso-de-validaci-n-y-puesta-en-producci-n).
+producción](#el-proceso-de-validacion-y-puesta-en-produccion).
 
 
 **Ambiente de producción**: Este ambiente es en el cual finalmente operará
@@ -183,7 +183,7 @@ valores entregados por el comercio al principio del flujo transaccional.
 
 ## Puesta en Producción
 
-Para el paso a producción el comercio debe realizar un [proceso de validación](#el-proceso-de-validaci-n-y-puesta-en-producci-n)
+Para el paso a producción el comercio debe realizar un [proceso de validación](#el-proceso-de-validacion-y-puesta-en-produccion)
 en el ambiente de integración. En este ambiente de integración Transbank le
 solicitará usar credenciales específicas para el comercio, de manera de simular
 lo mejor posible el ambiente productivo.

--- a/documentacion/patpass/README.md
+++ b/documentacion/patpass/README.md
@@ -150,7 +150,7 @@ Las credenciales de PatPass by Webpay se configuran de igual forma a las Webpay
 transacciones Webpay: en base a un objeto `Configuration`. Y si bien para hacer
 pruebas iniciales pueden usarse las credenciales pre-configuradas (como se puede
 ver en todos los ejemplos anteriores), para poder superar el [proceso de
-validación](/documentacion/como_empezar#el-proceso-de-validaci-n-y-puesta-en-producci-n)
+validación](/documentacion/como_empezar#el-proceso-de-validacion-y-puesta-en-produccion)
 en el ambiente de integración será necesario configurar explícitamente tu código
 de comercio y certificados:
 

--- a/documentacion/webpay/README.md
+++ b/documentacion/webpay/README.md
@@ -377,7 +377,7 @@ Ese objeto `Webpay` se configura en base a un objeto `Configuration`. Y si bien
 para hacer pruebas iniciales pueden usarse las credenciales pre-configuradas
 (como se puede ver en todos los ejemplos anteriores), para poder superar el
 [proceso de
-validación](/documentacion/como_empezar#el-proceso-de-validaci-n-y-puesta-en-producci-n)
+validación](/documentacion/como_empezar#el-proceso-de-validacion-y-puesta-en-produccion)
 en el ambiente de integración será necesario configurar explícitamente tu código
 de comercio y certificados:
 
@@ -512,7 +512,7 @@ Plus y Webpay OneClick:
 Webpay Plus Normal solo reserve el cupo y la captura de la transacción se pueda
 realizar posteriormente.
 
-- [Anular Transacciones Webpay Plus](/referencia/webpay#anulaci-n-webpay-plus) para devolver dinero parcial o
+- [Anular Transacciones Webpay Plus](/referencia/webpay#anulacion-webpay-plus) para devolver dinero parcial o
 totalmente.
 
 - [Reversar Transacciones Webpay OneClick](/referencia/webpay#reversar-un-pago-webpay-oneclick) para dejar sin efecto una

--- a/documentacion/webpay/README.md
+++ b/documentacion/webpay/README.md
@@ -158,7 +158,7 @@ if (output.responseCode == 0) {
 > no haya posibilidad de que la transacción se revierta. Si luego necesitas que
 > la transacción no se lleve a cabo (por ejemplo porque ya no tienes stock o
 > porque se generó un error en tu lógica de negocio que entrega el producto o
-> servicio), deberás [anular la transacción](/referencia/webpay#anulaci-n-webpay-plus).
+> servicio), deberás [anular la transacción](/referencia/webpay#anulacion-webpay-plus).
 
 En el caso exitoso deberás llevar el control vía `POST` nuevamente a Webpay para
 que el tarjetahabiente vea el comprobante que le deja claro que se ha realizado
@@ -518,7 +518,7 @@ totalmente.
 - [Reversar Transacciones Webpay OneClick](/referencia/webpay#reversar-un-pago-webpay-oneclick) para dejar sin efecto una
 transacción realizada durante el día.
 
-- [Eliminar Inscripciones Webpay OneClick](/referencia/webpay#eliminar-una-inscripci-n-webpay-oneclick) para eliminar el `tbkUser`
+- [Eliminar Inscripciones Webpay OneClick](/referencia/webpay#eliminar-una-inscripcion-webpay-oneclick) para eliminar el `tbkUser`
 cuando tus usuarios no quieren continuar con el servicio.
 
 - [Transacciones Webpay OneClick Mall](/referencia/webpay#webpay-oneclick-mall).

--- a/producto/webpay/README.md
+++ b/producto/webpay/README.md
@@ -120,7 +120,7 @@ Desde el punto de vista de la transacción, lo que ocurre es lo siguiente:
 ## Anulaciones
 
 <div class="pos-title-nav">
-  <div tbk-link='/referencia/webpay#anulaci-n-webpay-plus' tbk-link-name='Referencia Api'></div>
+  <div tbk-link='/referencia/webpay#anulacion-webpay-plus' tbk-link-name='Referencia Api'></div>
 </div>
 
 Las transacciones Webpay **realizadas con tarjeta de crédito** pueden ser anuladas mediante servicios web. Esta funcionalidad no aplica para tarjetas de débito Redcompra.

--- a/referencia/onepay/README.md
+++ b/referencia/onepay/README.md
@@ -324,7 +324,7 @@ Content-Type: application/json
 
 Nombre <br> <i>tipo</i>| Descripción<br>&nbsp;
 -------|------------
-responseCode<br> <i>  String  </i> |Código de respuesta que representa si la operación resultó exitosa o no. Puede tomar el valor `"OK"` (resultado exitoso),  `"INVALID_TRANSACTION"` (inconsistencia en el carro de compra en montos o cantidades), `"INVALID_PARAMS"` (otros parámetros incorrectos), `"TRANSACTION_ALREADY_EXISTS"` (External unique number ya había sido usado previamente), `"ILCAT_SERVICE_ERROR"` o `"ILCAT_RESPONSE_ERROR"` o `"ILCAT_ERROR"` (todos fallos internos). También puede tomar [uno de los valores comunes de error](#c-digos-de-error-comunes).
+responseCode<br> <i>  String  </i> |Código de respuesta que representa si la operación resultó exitosa o no. Puede tomar el valor `"OK"` (resultado exitoso),  `"INVALID_TRANSACTION"` (inconsistencia en el carro de compra en montos o cantidades), `"INVALID_PARAMS"` (otros parámetros incorrectos), `"TRANSACTION_ALREADY_EXISTS"` (External unique number ya había sido usado previamente), `"ILCAT_SERVICE_ERROR"` o `"ILCAT_RESPONSE_ERROR"` o `"ILCAT_ERROR"` (todos fallos internos). También puede tomar [uno de los valores comunes de error](#codigos-de-error-comunes).
 description <br> <i>  String  </i> | Contiene una descripción del resultado. Se utiliza para informar por qué ocurrio un error.
 result <br> <i>  Object  </i> | Tiene todos los datos de la transacción recién creada. Es `null` si el `responseCode` es diferente a `"OK"`.
 result.occ <br> <i>  String  </i> | Identificador único de la transacción en Onepay.
@@ -520,7 +520,7 @@ Content-Type: application/json
 
 Nombre <br> <i>tipo</i>| Descripción<br>&nbsp;
 ------ | -----------
-responseCode <br> <i>  String  </i> | Puede tomar el valor `"OK"` (resultado exitoso), `"INVALID_PARAMS"` (cuando los parámetros son incorrectos), `"INVALID_TRANSACTION"` o `"INVALID_TRANSACTION_STATUS"` (ambos indicando que la transacción no está autorizada y no se puede confirmar) También puede tomar [uno de los valores comunes de error](#c-digos-de-error-comunes).
+responseCode <br> <i>  String  </i> | Puede tomar el valor `"OK"` (resultado exitoso), `"INVALID_PARAMS"` (cuando los parámetros son incorrectos), `"INVALID_TRANSACTION"` o `"INVALID_TRANSACTION_STATUS"` (ambos indicando que la transacción no está autorizada y no se puede confirmar) También puede tomar [uno de los valores comunes de error](#codigos-de-error-comunes).
 description <br> <i>  String  </i> | Contiene una descripción del resultado. Se utiliza para informar por qué ocurrio un error.
 result <br> <i>  Object  </i> | Tiene todos los datos de la transacción recién creada. Es `null` si el `responseCode` es diferente a `"OK"`.
 result.occ <br> <i>  String  </i> | Identificador único de la transacción Onepay.
@@ -651,7 +651,7 @@ Content-Type: application/json
 
 Nombre <br> <i>tipo</i>| Descripción<br>&nbsp;
 ------ | -----------
-responseCode <br> <i>  String  </i> | Puede tomar el valor `"OK"` (resultado exitoso), `"INVALID_PARAMS"` (cuando los parámetros son incorrectos), `"INVALID_TRANSACTION"` o (la transacción no está autorizada y no se puede anular), `"INVALID_NULLIFY_AMOUNT`" (el monto no coincide con el de la transacción), `"NULLIFICATION_PERIOD_HAS_EXPIRED"` (ya no se puede anular la transacción), `"NONEXISTENT_TRANSACTION"` (la transacción no fue encontrada),  `"REVERSED_NULLIFY"` o `"FAILED_REVERSE_NULLIFY"` o  `"NONEXISTENT_USER"` o `"INVALID_USER"` o  `"NOT_ACTIVE_COMMERCE"` o `"ERROR"` (todos errores inesperados), También puede tomar [uno de los valores comunes de error](#c-digos-de-error-comunes).
+responseCode <br> <i>  String  </i> | Puede tomar el valor `"OK"` (resultado exitoso), `"INVALID_PARAMS"` (cuando los parámetros son incorrectos), `"INVALID_TRANSACTION"` o (la transacción no está autorizada y no se puede anular), `"INVALID_NULLIFY_AMOUNT`" (el monto no coincide con el de la transacción), `"NULLIFICATION_PERIOD_HAS_EXPIRED"` (ya no se puede anular la transacción), `"NONEXISTENT_TRANSACTION"` (la transacción no fue encontrada),  `"REVERSED_NULLIFY"` o `"FAILED_REVERSE_NULLIFY"` o  `"NONEXISTENT_USER"` o `"INVALID_USER"` o  `"NOT_ACTIVE_COMMERCE"` o `"ERROR"` (todos errores inesperados), También puede tomar [uno de los valores comunes de error](#codigos-de-error-comunes).
 description <br> <i>  String  </i> | Contiene una descripción del resultado. Se utiliza para informar por qué ocurrio un error.
 result <br> <i>  Object  </i> | Tiene todos los datos de la transacción recién creada. Es `null` si el `responseCode` es diferente a `"OK"`.
 result.occ <br> <i>  String  </i> | Identificador único de la transacción Onepay.
@@ -1061,9 +1061,9 @@ status | Estado resultante de la transacción. Puede ser `"PRE_AUTHORIZED"` (tra
 issuedAt | Fecha de creación de la transacción como timestamp unix.
 Los parámetros son todos String (pues son parte de una URL),
 
-Si quieres saber más sobre cómo manejar la invocación a tu  `appScheme`, [consulta la gúia de Onepay en la sección de integración para app móvil](/documentacion/onepay#integraci-n-en-app-m-vil).
+Si quieres saber más sobre cómo manejar la invocación a tu  `appScheme`, [consulta la gúia de Onepay en la sección de integración para app móvil](/documentacion/onepay#integracion-en-app-movil).
 
-Finalmente deberás enviar a tu backend la información que recibiste para que [confirme la transacción usando el API o uno de nuestros SDK backend](#confirmar-una-transacci-n).
+Finalmente deberás enviar a tu backend la información que recibiste para que [confirme la transacción usando el API o uno de nuestros SDK backend](#confirmar-una-transaccion).
 
 ### Retomar el control en tu app Android
 
@@ -1083,9 +1083,9 @@ externalUniqueNumber <br> <i>  String  </i> | Identificador de la transacción e
 status <br> <i>  String  </i> | Estado resultante de la transacción. Puede ser `"PRE_AUTHORIZED"` (transacción autorizada por el usuario), `"CANCELLED_BY_USER"`(el usuario abortó el pago) o `"REJECTED"` (transacción rechazada por el autorizador). También puede tomar el valor `"REVERSED"` (la transacción se reversó internamente después de no poder confirmar el pago) o `"REVERSE_NOT_COMPLETE"` (se intentó reversar, pero falló por alguna razón), pero estos casos deben ser manejados de igual forma que `"REJECTED"`.
 issuedAt <br> <i>  Long  </i> | Fecha de creación de la transacción como timestamp unix.
 
-Si quieres saber más sobre cómo configurar tu `Activity` para que reciba la invocación de Onepay, [consulta la gúia de Onepay en la sección de integración para app móvil](/documentacion/onepay#integraci-n-en-app-m-vil).
+Si quieres saber más sobre cómo configurar tu `Activity` para que reciba la invocación de Onepay, [consulta la gúia de Onepay en la sección de integración para app móvil](/documentacion/onepay#integracion-en-app-movil).
 
-Finalmente deberás enviar a tu backend la información que recibiste para que [confirme la transacción usando el API o uno de nuestros SDK backend](#confirmar-una-transacci-n).
+Finalmente deberás enviar a tu backend la información que recibiste para que [confirme la transacción usando el API o uno de nuestros SDK backend](#confirmar-una-transaccion).
 
 
 

--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -895,7 +895,7 @@ autorizada pero requerirá una captura explícita posterior para confirmar la
 transacción.
 
 Puedes [leer más sobre la captura en la información del
-producto Webpay](/producto/webpay#autorizaci-n-y-captura)
+producto Webpay](/producto/webpay#autorizacion-y-captura)
 para concer más detalles y restricciones.
 
 Para realizar esa captura explícita debe usarse el método `capture()`


### PR DESCRIPTION
Cumbre modified their slate thingy so that accented characters would be replaced by non-accented ones instead of the generic `-` character. So we need to keep the upstream markdown updated to minimize chances of conflict when the automated scripts move our markdown files into their slate.