### PR TITLE
Add docs for OneClick nullify.

### DIFF
--- a/documentacion/webpay/README.md
+++ b/documentacion/webpay/README.md
@@ -516,7 +516,12 @@ realizar posteriormente.
 totalmente.
 
 - [Reversar Transacciones Webpay OneClick](/referencia/webpay#reversar-un-pago-webpay-oneclick) para dejar sin efecto una
-transacción realizada durante el día.
+transacción realizada durante el día contable actual.
+
+- [Anular Transacciones Webpay
+  OneClick](/referencia/webpay#anular-un-pago-webpay-oneclick) para dejar sin
+  efecto una transacción realizada en otra fecha distinta al día contable
+  actual.
 
 - [Eliminar Inscripciones Webpay OneClick](/referencia/webpay#eliminar-una-inscripcion-webpay-oneclick) para eliminar el `tbkUser`
 cuando tus usuarios no quieren continuar con el servicio.

--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -1504,6 +1504,12 @@ Nombre  <br> <i> tipo </i> | Descripción
 reversed  <br> <i> xs:boolean </i> | Indica si tuvo éxito la reversa.
 reverseCode  <br> <i> xs:long </i> | Identificador único de la transacción de reversa.
 
+### Anular un pago Webpay OneClick
+
+En caso que ya no sea el mismo día contable y se requiera dejar sin efecto una
+venta, es posible anular un pago realizado con Webpay OneClick Normal usando [el
+mismo método de anulación Webpay Plus](#anulacion-webpay-plus).
+
 ### Eliminar una inscripción Webpay OneClick
 
 En el caso que el comercio requiera eliminar la inscripción de un usuario en


### PR DESCRIPTION
It turns out that the nullify method from Webpay Plus works for OneClick as well.
We might have to rethink the 'Otros servicios Webpay Plus' title in the future,
as both nullify and defered capture seem to work across all Webpay transactions
(but I'm not totally sure they work for Webpay Oneclick Mall)