### PR TITLE
Simplify explanation of negative item quantity

### DIFF
--- a/documentacion/onepay/README.md
+++ b/documentacion/onepay/README.md
@@ -251,41 +251,6 @@ cart.add(Item(description="Zapatos",
               additional_data=None, expire=None))
 ```
 
-### `Item` con `amount` negativo
-
-<div class="language-simple" data-multiple-language></div>
-
-```php
-$cart->add(new Item('Descuento', 1, -100));
-```
-
-```java
-cart.add(new Item()
-        .setDescription("Descuento")
-        .setQuantity(1)
-        .setAmount(-100));
-```
-
-```csharp
-cart.Add(new Item(description: "Descuento",
-                quantity: 1,
-                amount: -100));
-```
-
-```ruby
-cart.add(Transbank::Onepay::Item.new(amount: -100,
-                quantity: 1,
-                description: "Descuento"))
-```
-
-```python
-cart.add(Item(description="Descuento",
-            quantity=1,
-            amount=-100))
-```
-
-Se permite agregar un `Item` al carro con `amount` negativo que generalmente representa un descuento. Lo importante es que el monto total en el carro de compras debe ser positivo, en caso contrario se lanzará una excepción.
-
 Luego que el carro de compras contiene todos los ítems, se crea la transacción:
 
 

--- a/referencia/onepay/README.md
+++ b/referencia/onepay/README.md
@@ -257,7 +257,7 @@ appScheme <br> <i>  String  </i> | Esquema de retorno a la aplicación del comer
 items <br> <i>  Array[Object]  </i> | Lista de items en el carro de compra. Corresponde al primer parámetro en los SDKs.
 items[].description <br> <i>  String  </i> | Descripción del ítem.
 items[].quantity <br> <i>  Number  </i> | Cantidad para el ítem descrito.
-items[].amount <br> <i>  Number  </i> | Precio unitario.
+items[].amount <br> <i>  Number  </i> | Precio unitario. Puede ser negativo para representar un descuento, siempre que el monto total del carro (sumando todos los items) sea positivo.
 items[].additionalData <br> <i>  String  </i> | 
 items[].expire <br> <i>  Number  </i> |
 


### PR DESCRIPTION
Feedback from people says that the current section on the main documentation is a bit
confusing as it breaks the flow of the main explanation to integrate a web application with
Onepay.

So this moves the explanation to the reference documentation which is better for
documenting special cases.