### PR TITLE
Specify external dependencies to make work the QR component in Onepay Android SDK

### DIFF
--- a/referencia/onepay/README.md
+++ b/referencia/onepay/README.md
@@ -1093,7 +1093,16 @@ Finalmente deberás enviar a tu backend la información que recibiste para que [
 
 Para la [modalidad Cortafilas](/documentacion/onepay#integracion-cortafila), hemos dispuesto en el SDK Android un componente que dibujará el QR a partir de la ott.
 
-Para integrar este componente, debes agregar en tu archivo layout:
+Para integrar este componente, debes agregar en el archivo build.gradle del módulo que contiene tu proyecto Android (generalmente en app/build.gradle), las siguientes dependencias:
+
+```
+dependencies {
+	implementation 'com.google.zxing:core:3.3.0'
+	implementation('com.journeyapps:zxing-android-embedded:3.6.0') { transitive = false }
+}
+```    
+
+También debes agregar en tu archivo layout:
 
 ```xml
 <cl.ionix.tbk_ewallet_sdk_android.ui.QROnepayView


### PR DESCRIPTION
When a library is generated as an .aar file, it do not carry any external dependency specified on the build.gradle file. This problem could be addressed taking this library to Maven Central.

Meanwhile, I've added the instruction to manually add the dependencies that are needed by the Onepay Android SDK.