### PR TITLE
Revert "Restore PatPass references in quickstart and product info"

### DIFF
--- a/documentacion/como_empezar/README.md
+++ b/documentacion/como_empezar/README.md
@@ -86,7 +86,7 @@ Transbank provee dos ambientes para todos sus productos:
 la integración a Webpay y testea su solución de medio pago. Asimismo, en éste
 ambiente es que se valida la integración del comercio.
 
-Para las transaccciones Webpay y PatPass en estos ambientes se deben usar estas
+Para las transaccciones Webpay en estos ambientes se deben usar estas
 tarjetas:
 
 - VISA 4051885600446623, CVV 123, cualquier fecha de expiración. Esta tarjeta
@@ -108,7 +108,6 @@ como probar nuestros productos en este ambiente:
 - [Webpay Plus](webpay#webpay-plus)
 - [Webpay OneClick](webpay#webpay-oneclick)
 - [Onepay Checkout](onepay#integracion-checkout)
-- [PatPass by Webpay](patpass#patpass-by-webpay)
 
 Después de haber realizado esas pruebas iniciales y antes del paso a producción
 tendrás que usar credenciales que identifiquen a tu comercio. De esa forma
@@ -201,9 +200,9 @@ Estos valores serán provistos por transbank y en su conjunto permiten hacer
 transacciones a nombre del comercio. **Debes custodiar estas credenciales para
 evitar que caigan en manos de terceros**.
 
-### Credenciales en Webpay y PatPass
+### Credenciales en Webpay
 
-En el caso de Webpay y PatPass by Webpay, las credenciales consisten en:
+En el caso de Webpay, las credenciales consisten en:
 
 - Un código de comercio.
 - Una llave privada.
@@ -315,7 +314,7 @@ producción.
 <aside class="warning">
 Importante: Es responsabilidad del comercio considerar que el certificado
 público que Transbank comparte con los comercios (y que es incluido en los SDKs)
-para integraciones de Webpay y PatPass tiene una fecha de caducidad, como
+para integraciones de Webpay tiene una fecha de caducidad, como
 asimismo el certificado que el comercio genera y que comparte con Transbank para
 realizar las transacciones sobre Webpay. El comercio es responsable por
 resguardar su llave privada y su certificado público, como asimismo es
@@ -325,7 +324,7 @@ responsable por reemplazar estos cuando caduquen.
 
 ## Requerimientos de páginas de transición y de fin de transacción
 
-### Webpay y PatPass
+### Webpay
 
 **La página de transición** de comercio, es la página que muestra el comercio
 cuando Webpay le entrega el control, después del proceso de autorización y

--- a/producto/webpay/README.md
+++ b/producto/webpay/README.md
@@ -65,11 +65,6 @@ El modelo de pago contempla un proceso previo de inscripción o enrolamiento de
 
 4. Finalizada la autorización, Webpay entrega al comercio la información que le permitirá realizar realizar cobros a futuro usando [otro servicio web provisto para ese fin](/documentacion/webpay#realizar-transacciones).
 
-El tipo de transacción OneClick es útil para bajar la fricción en comercios en
-los cuales el tarjetahabiente realiza compras frecuentemente pero sin un patrón
-fijo. En el caso de suscripciones mensuales se debe utilizar
-[PatPass](patpass).
-
  Al no contar con sistema de autenticación bancaria en los cargos que se realizan después de la autorización, será el comercio el responsable de asumir el riesgo de fraude o desconocimientos de compra que realice un tarjetahabiente.
 
 ### Webpay OneClick Mall

--- a/referencia/patpass/README.md
+++ b/referencia/patpass/README.md
@@ -113,8 +113,7 @@ Puedes mirar el siguiente enlace para obtener una guía rápida de como generar 
 </aside>
 
 Consulta [la documentación para generar una llave privada y un certificado
-usando openssl](/documentacion/como_empezar#credenciales-en-webpay-y-patpass si
-no sabes aún como realizarlo.
+usando openssl](/documentacion/como_empezar#credenciales-en-webpay si no sabes aún como realizarlo.
 
 En [el repositorio github
 `transbank-webpay-credenciales`](https://github.com/TransbankDevelopers/transbank-webpay-credenciales/)

--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -136,7 +136,7 @@ propio archivo: [Crear archivo pfx usando openssl](https://www.ssl.com/how-to/cr
 </aside>
 
 Consulta [la documentación para generar una llave privada y un certificado
-usando openssl](/documentacion/como_empezar#credenciales-en-webpay-y-patpass) si
+usando openssl](/documentacion/como_empezar#credenciales-en-webpay) si
 no sabes aún como realizarlo.
 
 En [el repositorio github


### PR DESCRIPTION
Reverts TransbankDevelopers/transbank-developers-docs#58 because these changes were blocking any new changes made to the docs from getting into production. The reason is because PatPass is not yet officially launched and therefore there shouldn't be any references to it publicly.