### PR TITLE
Fix PHP production configuration in 'Referencia API'

### DIFF
--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -40,7 +40,7 @@ configuration.setWebpayCert(
 ```
 
 ```php
-$configuration->setWebpayCert(Webpay::defaultCert());
+$configuration->setWebpayCert(Webpay::defaultCert("PRODUCCION"));
 ```
 
 ```csharp

--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -40,13 +40,7 @@ configuration.setWebpayCert(
 ```
 
 ```php
-$configuration->setWebpayCert(
-    "-----BEGIN CERTIFICATE-----\n" +
-    "MIIEDzCCAvegAwIBAgIJAMaH4DFTKdnJMA0GCSqGSIb3DQEBCwUAMIGdMQswCQYD\n" +
-    "VQQGEwJDTDERMA8GA1UECAwIU2FudGlhZ28xETAPBgNVBAcMCFNhbnRpYWdvMRcw\n" +
-    ...
-    "MX5lzVXafBH/sPd545fBH2J3xAY3jtP764G4M8JayOFzGB0=\n" +
-    "-----END CERTIFICATE-----\n");
+$configuration->setWebpayCert(Webpay::defaultCert());
 ```
 
 ```csharp
@@ -98,13 +92,13 @@ configuration.setPublicCert(
 ```php
 $configuration->setCommerceCode("597020000540");
 $configuration->setPrivateKey(
-    "-----BEGIN RSA PRIVATE KEY-----\n" +
-    ... +
+    "-----BEGIN RSA PRIVATE KEY-----\n" .
+    ... .
     "-----END RSA PRIVATE KEY-----\n"
 );
 $configuration->setPublicCert(
-    "-----BEGIN CERTIFICATE-----\n" +
-    ... +
+    "-----BEGIN CERTIFICATE-----\n" .
+    ... .
     "-----END CERTIFICATE-----\n"
 );
 ```


### PR DESCRIPTION
- The documentation show a wrong way to concatenate string on php
- Recommend use `Webpay::defaultCert()` to assign the Webpay certificate.

related to this [Jira card](https://transbank-developers.atlassian.net/browse/TD-316?atlOrigin=eyJpIjoiYjI3YmM0NDM0YmUyNDY1Yzk2MDY4YzllOWM2YTE4ZmYiLCJwIjoiaiJ9)