### PR TITLE
Update max php version plugins

### DIFF
--- a/plugin/magento/webpay/README.md
+++ b/plugin/magento/webpay/README.md
@@ -6,7 +6,7 @@
     <h4>Compatibilidad</h4>
     <ul>
       <li>Magento >= 2.0</li>
-      <li>PHP >= 5.6 y PHP <= 7.1</li>
+      <li>PHP >= 5.6 y PHP <= 7.2</li>
     </ul>
     <h4>Recuerda</h4>
     <ol>

--- a/plugin/prestashop/webpay/README.md
+++ b/plugin/prestashop/webpay/README.md
@@ -9,7 +9,7 @@
     <h4>Compatibilidad</h4>
     <ul>
       <li>Prestashop >= 1.6</li>
-      <li>PHP >= 5.6 y PHP <= 7.1</li>
+      <li>PHP >= 5.6 y PHP <= 7.2</li>
     </ul>
     <h4>Recuerda</h4>
     <ol>

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -9,7 +9,7 @@
     <h4>Compatibilidad</h4>
     <ul>
       <li>Woocommerce >= 3.2</li>
-      <li>PHP >= 5.6 y PHP <= 7.1</li>
+      <li>PHP >= 5.6 y PHP <= 7.2</li>
     </ul>
     <h4>Recuerda</h4>
     <ol>


### PR DESCRIPTION
Update documentation to webpay on Prestashop, WooCommerce and Magento2.
7.2 is the new maximum Php version.