### PR TITLE
Update docs add certificates tip

### DIFF
--- a/plugin/magento/webpay/README.md
+++ b/plugin/magento/webpay/README.md
@@ -99,7 +99,7 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
 <aside class="notice">
-  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+  Tip: Ya no es necesario configurar el **Certificado Transbank**, en versiones anteriores era requerido, actualmente este se reemplaza al seleccionar **ambiente**.
 </aside>
 
 ### Credenciales de Prueba

--- a/plugin/magento/webpay/README.md
+++ b/plugin/magento/webpay/README.md
@@ -98,6 +98,10 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
+<aside class="notice">
+  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+</aside>
+
 ### Credenciales de Prueba
 
 Para el ambiente de Integración, puedes utilizar las siguientes credenciales para realizar pruebas:

--- a/plugin/opencart/webpay/README.md
+++ b/plugin/opencart/webpay/README.md
@@ -98,7 +98,7 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
 <aside class="notice">
-  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+  Tip: Ya no es necesario configurar el **Certificado Transbank**, en versiones anteriores era requerido, actualmente este se reemplaza al seleccionar **ambiente**.
 </aside>
 
 ### Configuración de los estados de la orden

--- a/plugin/opencart/webpay/README.md
+++ b/plugin/opencart/webpay/README.md
@@ -97,6 +97,10 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
+<aside class="notice">
+  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+</aside>
+
 ### Configuración de los estados de la orden
 
 Asegurate de configurar correctamente los estados de la orden según corresponda a tu comercio:

--- a/plugin/prestashop/webpay/README.md
+++ b/plugin/prestashop/webpay/README.md
@@ -80,6 +80,10 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
+<aside class="notice">
+  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+</aside>
+
 ### Credenciales de Prueba
 
 Para el ambiente de Integración, puedes utilizar las siguientes credenciales para realizar pruebas:

--- a/plugin/prestashop/webpay/README.md
+++ b/plugin/prestashop/webpay/README.md
@@ -81,7 +81,7 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
 <aside class="notice">
-  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+  Tip: Ya no es necesario configurar el **Certificado Transbank**, en versiones anteriores era requerido, actualmente este se reemplaza al seleccionar **ambiente**.
 </aside>
 
 ### Credenciales de Prueba

--- a/plugin/virtuemart/webpay/README.md
+++ b/plugin/virtuemart/webpay/README.md
@@ -97,10 +97,6 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
-<aside class="notice">
-  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
-</aside>
-
 ### Credenciales de Prueba
 
 Para el ambiente de Integración, puedes utilizar las siguientes credenciales para realizar pruebas:

--- a/plugin/virtuemart/webpay/README.md
+++ b/plugin/virtuemart/webpay/README.md
@@ -97,6 +97,10 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
+<aside class="notice">
+  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+</aside>
+
 ### Credenciales de Prueba
 
 Para el ambiente de Integración, puedes utilizar las siguientes credenciales para realizar pruebas:

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -4,7 +4,7 @@
   <div class="btn-side-right"><span><img src="/images/navbar.png"></span></div>
   <div class="block-cantainer">
     <h4>Descarga nuestro plugin.</h4>
-    <a class="td_btn-more" target="_blank" href="https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay/releases/latest">Descargar Plugin</a>
+    <a class="td_btn-more" target="_blank"  href="https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay/releases/latest">Descargar Plugin</a>
     <br>
     <h4>Compatibilidad</h4>
     <ul>
@@ -79,6 +79,10 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
    - **Certificado**: Llave publica que te autoriza y valida a hacer transacciones.
 
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
+
+<aside class="notice">
+  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+</aside>
 
 ### Credenciales de Prueba
 

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -81,7 +81,7 @@ Para acceder a la configuración, debes seguir los siguientes pasos:
   Las opciones disponibles para _Ambiente_ son: "Integración" para realizar pruebas y certificar la instalación con Transbank, y "Producción" para hacer transacciones reales una vez que Transbank ha aprobado el comercio.
 
 <aside class="notice">
-  Tip: No es necesario que cambies el certificado de Transbank, ya que este se reemplaza al seleccionar el **ambiente**.
+  Tip: Ya no es necesario configurar el **Certificado Transbank**, en versiones anteriores era requerido, actualmente este se reemplaza al seleccionar **ambiente**.
 </aside>
 
 ### Credenciales de Prueba


### PR DESCRIPTION
The webpay plugins docs have been updated to show new information about the Transbank's certificates and how now are not necessaries to integrate.