### PR TITLE
Add acknowledgeTransaction error message on warming message

### DIFF
--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -274,8 +274,9 @@ Desde el punto de vista técnico, la secuencia es la siguiente:
 De no ser consumido `acknowledgeTransaction()` o demorar más de 30 segundos en
 su consumo, Webpay realizará la reversa de la transacción, asumiendo que
 existieron problemas de comunicación. En este caso el método retorna una
-Excepción indicando la situación. Esta excepción debe ser manejada para no
-entregar el producto o servicio en caso que ocurra.
+Excepción indicando la situación, el mensaje obtenido en la excepción será
+`Timeout error (Transaction is REVERSED)(272)`. Esta excepción debe ser manejada
+para no entregar el producto o servicio en caso que ocurra.
 </aside>
 
 14. Una vez recibido el resultado de la transacción e informado a Webpay su


### PR DESCRIPTION
Some developers are confused when they gets the response `Timeout error (Transaction is REVERSED)(272)`, because they do not know that this is the acknowledgeTransaction exception. So we add this message in the warning section.