### PR TITLE
Feat/add error 21

### DIFF
--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -403,7 +403,7 @@ url  <br> <i> xs:string </i> | URL de formulario de pago Webpay. Largo máximo:
 
 <aside class="warning">
 El número de orden de compra (`buyOrder`) debe ser único para cada transacción.
-Si un `buyOrder` es enviado dos o más veces se obtendrá el error ` Transaction already exists(21)`
+Si un `buyOrder` es enviado dos o más veces se obtendrá el error `Transaction already exists(21)`
 </aside>
 
 ### Confirmar una transacción Webpay Plus Normal
@@ -710,6 +710,11 @@ Nombre  <br> <i> tipo </i> | Descripción
 ------   | -----------
 token  <br> <i> xs:string </i> | Token de la transacción. Largo: 64.
 url  <br> <i> xs:string </i> | URL de formulario de pago Webpay. Largo máximo: 256.
+
+<aside class="warning">
+El número de orden de compra (`buyOrder`) debe ser único para cada transacción.
+Si un `buyOrder` es enviado dos o más veces se obtendrá el error `Transaction already exists(21)`
+</aside>
 
 ### Confirmar una transacción Webpay Plus Mall
 


### PR DESCRIPTION
the buyOrder should not be reused, but in the case that a commerce tries to send the same buyOrder in two or more occasions the `initTransaction` will return the error `Transaction already exists(21)`