### PR TITLE
Fix title of 'abort payment flow'

### DIFF
--- a/referencia/webpay/README.md
+++ b/referencia/webpay/README.md
@@ -297,7 +297,7 @@ para no entregar el producto o servicio en caso que ocurra.
     initTransaction.
 18. Sitio del comercio despliega página final de pago
 
-#### Flujo si usuario aborta el pago
+### Flujo si usuario aborta el pago
 
 <img class="td_img-night" src="/images/diagrama-secuencia-webpay-abortar.png" alt="Diagrama de secuencia si usuario aborta el pago">
 


### PR DESCRIPTION
To fix the title "Flujo si el usuario aborta...": 
![image](https://user-images.githubusercontent.com/1103494/92759258-ee17b900-f365-11ea-8852-94ec8cbd909a.png)
