### PR TITLE
Add new videos

### DIFF
--- a/plugin/magento/webpay-soap/README.md
+++ b/plugin/magento/webpay-soap/README.md
@@ -16,6 +16,12 @@
   </div>
 </div>
 
+---
+
+<aside class="warning">
+Estás viendo una versión <strong>antigua de la documentación</strong> de este plugin. Si quieres ver la nueva versión (REST) haz [click aquí](/plugin/magento/webpay)
+</aside>
+
 <h1 class="toc-ignore">Webpay Magento2</h1>
 <h1 style="display: none;">Webpay</h1>
 

--- a/plugin/magento/webpay/README.md
+++ b/plugin/magento/webpay/README.md
@@ -98,6 +98,15 @@ Nota: Esta **llave secreta** es como la contraseña de tu código de comercio, p
 
 ## Puesta en producción
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=B9sb7SyROVk" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo pasar a producción</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 Si ya tienes tu código de comercio de producción y llave secreta, solo debes entrar a la configuración de tu plugin ([instrucciones en este link](https://github.com/TransbankDevelopers/transbank-plugin-magento2-webpay-rest/blob/master/docs/INSTALLATION.md#configuraci%C3%B3n)) y colocar:
 
 * Ambiente: Producción

--- a/plugin/opencart/webpay-soap/README.md
+++ b/plugin/opencart/webpay-soap/README.md
@@ -19,6 +19,12 @@
   </div>
 </div>
 
+---
+
+<aside class="warning">
+Estás viendo una versión <strong>antigua de la documentación</strong> de este plugin. Si quieres ver la nueva versión (REST) haz [click aquí](/plugin/opencart/webpay)
+</aside>
+
 <h1 class="toc-ignore">Webpay Opencart</h1>
 <h1 style="display: none;">Webpay</h1>
 

--- a/plugin/opencart/webpay/README.md
+++ b/plugin/opencart/webpay/README.md
@@ -67,6 +67,15 @@ Nota: Esta **llave secreta** es como la contraseña de tu código de comercio, p
 
 ## Puesta en producción
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=B9sb7SyROVk" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo pasar a producción</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 Si ya tienes tu código de comercio de producción y llave secreta, solo debes entrar a la configuración de tu plugin ([instrucciones en este link](https://github.com/TransbankDevelopers/transbank-plugin-opencart-webpay-rest/blob/master/docs/INSTALLATION.md#configuraci%C3%B3n)) y colocar:
 
 * Ambiente: Producción

--- a/plugin/prestashop/webpay-soap/README.md
+++ b/plugin/prestashop/webpay-soap/README.md
@@ -19,14 +19,16 @@
   </div>
 </div>
 
+---
+
+<aside class="warning">
+Estás viendo una versión <strong>antigua de la documentación</strong> de este plugin. Si quieres ver la nueva versión (REST) haz [click aquí](/plugin/prestashop/webpay)
+</aside>
+
 <h1 class="toc-ignore">Webpay Prestashop</h1>
 <h1 style="display: none;">Webpay</h1>
 
 ## Descripción
-
-<aside class="notice">
-Estás viendo la versión SOAP de este plugin.
-</aside>
 
 Este plugin oficial ha sido creado para que puedas integrar Webpay fácilmente en tu comercio, basado en Prestashop.
 

--- a/plugin/prestashop/webpay/README.md
+++ b/plugin/prestashop/webpay/README.md
@@ -77,6 +77,15 @@ Soporte validará el formulario enviado y, de estar todo correcto, se te notifi
 
 ## Puesta en producción
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=B9sb7SyROVk" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo pasar a producción</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 Si ya tienes tu código de comercio de producción y llave secreta, solo debes entrar a la configuración de tu plugin ([instrucciones en este link](https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay-rest/blob/master/docs/INSTALLATION.md#configuraci%C3%B3n)) y colocar:
 
 * Ambiente: Producción

--- a/plugin/virtuemart/webpay-soap/README.md
+++ b/plugin/virtuemart/webpay-soap/README.md
@@ -19,15 +19,17 @@
   </div>
 </div>
 
+---
+
+<aside class="notice">
+Estás viendo la antigua documentación <strong>SOAP</strong> de este plugin. Si quieres ver referencia de la versión actual
+(REST) haz [click aquí](/plugin/virtuemart/webpay)
+</aside>
+
 <h1 class="toc-ignore">Webpay Virtuemart</h1>
 <h1 style="display: none;">Webpay</h1>
 
 ## Descripción
-
-<aside class="notice">
-Estás viendo la antigua documentación <strong>SOAP</strong> de este plugin. Si quieres ver referencia de la versión actual
-(REST) haz [click aquí](/plugin/virtuemart/)
-</aside>
 
 Este plugin oficial ha sido creado para que puedas integrar Webpay fácilmente en tu comercio, basado en Virtuemart.
 

--- a/plugin/virtuemart/webpay/README.md
+++ b/plugin/virtuemart/webpay/README.md
@@ -71,6 +71,15 @@ Nota: Esta **llave secreta** es como la contraseña de tu código de comercio, p
 
 ## Puesta en producción
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=B9sb7SyROVk" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo pasar a producción</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 Si ya tienes tu código de comercio de producción y llave secreta, solo debes entrar a la configuración de tu plugin ([instrucciones en este link](https://github.com/TransbankDevelopers/transbank-plugin-virtuemart-webpay-rest/blob/master/docs/INSTALLATION.md#configuraci%C3%B3n)) y colocar:
 
 * Ambiente: Producción

--- a/plugin/woocommerce/webpay-soap/README.md
+++ b/plugin/woocommerce/webpay-soap/README.md
@@ -19,6 +19,21 @@
   </div>
 </div>
 
+---
+
+<aside class="warning">
+Estás viendo una versión <strong>antigua de la documentación</strong> de este plugin. Si quieres ver la nueva versión (REST) haz [click aquí](/plugin/woocommerce/webpay)
+</aside>
+
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/embed/9--NHgh07Fw" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Como pasar de SOAP a REST</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 <h1 class="toc-ignore">Webpay WooCommerce</h1>
 <h1 style="display: none;">Webpay</h1>
 

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -74,17 +74,19 @@ _Esta pantalla de diagnóstico se encuentra en la sección de configuración del
 Las instrucciones detalladas de instalación las puedes encontrar en el [siguiente link](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/blob/master/docs/INSTALLATION.md).
 
 ## Cómo usar
-Una vez instalado agregará un nuevo método de pago disponible en tu WooCommerce. Si no se activa correctamente, revisa que el plugin esté activo y que tu tienda está configurada en Pesos Chilenos. 
+
+Una vez instalado agregará un nuevo método de pago disponible en tu WooCommerce. Si no se activa correctamente, revisa que el plugin esté activo y que tu tienda está configurada en Pesos Chilenos.
 
 Como nuevo método de pago, tus clientes podrán pagar por sus pedidos usando la opción Webpay Plus en el proceso de Checkout, y una vez finalizado el pago, la orden será aprobada automáticamente (si el pago fue realizado correctamente).
 Dentro de la lista de órdenes verás cuales están pagadas. En el detalle de una orden verás también algunas notas (Notas de la orden) donde puedes verificar cual fue el resultado detallado de la transacción (código de autorización, tipo de tarjeta, etc )  
 
 ### Anulaciones
-Dentro del detalle de una orden, podrás realizar una anulación o reversa de un pago. 
+
+Dentro del detalle de una orden, podrás realizar una anulación o reversa de un pago.
 Puedes ver el detalle de una reversa o anulación ("refund") [en este link](https://transbankdevelopers.cl/documentacion/webpay-plus#reversar-o-anular-una-transaccion)
 
 Las tarjetas de débito solo soportan Reversas (refunds realizados dentro de los primeros 30 minutos de aprobada la transacción). 
-En tarjetas de crédito se permiten reversas, anulaciones y anulaciones parciales. 
+En tarjetas de crédito se permiten reversas, anulaciones y anulaciones parciales.
 
 En el siguiente video te mostramos como realizar el proceso: 
 <div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube-nocookie.com/embed/ogw2yHcaZ4M" >
@@ -96,10 +98,10 @@ En el siguiente video te mostramos como realizar el proceso:
   </div>
 </div>
 
-### Consultar estado 
+### Consultar estado
 
-También en el detalle de una orden, se puede revisar el estado actual de una transacción (hasta por 7 días de realizada la transacción). 
-Se puede revisar si una transacción está autorizada, anulada, parcialmente anulada o reversada. 
+También en el detalle de una orden, se puede revisar el estado actual de una transacción (hasta por 7 días de realizada la transacción).
+Se puede revisar si una transacción está autorizada, anulada, parcialmente anulada o reversada.
 
 En el siguiente video te dejamos las instrucciones para realizar este proceso
 <div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube-nocookie.com/embed/AB9eh7BTJUE" >
@@ -136,6 +138,15 @@ Planilla de validación para plugins oficiales: [Descargar](https://transbankdev
 Soporte validará el formulario enviado y, de estar todo correcto, se te notificará la conformidad para pasar a producción, recibiendo tu **llave secreta** (_Api Key Secret_) de producción y algunas instrucciones.
 
 ## Puesta en producción
+
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=B9sb7SyROVk" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo pasar a producción</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
 
 Si ya tienes tu código de comercio de producción y llave secreta, solo debes entrar a la configuración de tu plugin ([instrucciones en este link](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/blob/master/docs/INSTALLATION.md#configuraci%C3%B3n)) y colocar:
 

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -19,7 +19,6 @@
   </div>
 </div>
 
-
 ___
 
 <aside class="notice">

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -42,6 +42,15 @@ Estás viendo la <strong>nueva documentación REST</strong> de este plugin. Si q
 
 Este plugin oficial ha sido creado para que puedas integrar Webpay fácilmente en tu comercio, basado en WooCommerce.
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/watch?v=IeKb8RreF08" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Cómo instalar el plugin de woocommerce</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 ## Requisitos
 
 Debes tener instalado previamente [WooCommerce](https://woocommerce.com/).

--- a/plugin/woocommerce/webpay/README.md
+++ b/plugin/woocommerce/webpay/README.md
@@ -26,6 +26,15 @@ Estás viendo la <strong>nueva documentación REST</strong> de este plugin. Si q
 (SOAP) haz [click aquí](/plugin/woocommerce/webpay-soap)
 </aside>
 
+<div class='url-modal-embed' data-toggle-embedYT="modal" data-src="https://www.youtube.com/embed/9--NHgh07Fw" >
+  <div class="container-embed">
+    <div class="data-info-url">
+      <b>Como pasar de SOAP a REST</b>
+    </div>
+    <img class="icon-video-YT td_img-night" src="{{dir}}/images/yt_icon.png" alt="Youtube">
+  </div>
+</div>
+
 <h1 class="toc-ignore">Webpay REST WooCommerce</h1>
 <h1 style="display: none;">Webpay REST</h1>
 


### PR DESCRIPTION
Add plugin videos:
- Woocommerce how to go from SOAP to REST.
- Woocommerce how to install.
- All how to go Live with a plugin.

Also, adds some missing outdated SOAP plugin warnings.